### PR TITLE
[fix] dependency fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
             <version>${org.osiam.connector4java.version}</version>
         </dependency>
 
+        <!-- Jersey for requests that are not made via the connector -->
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+            <version>2.12</version>
+        </dependency>
+
         <!-- JSTL for Tomcat -->
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Jersey dependency is transitively introduced via the
connector4java dependency. this will break compatibility with the new
dependency-reduced connector version (1.2), so fixing this upfront now.

see also https://github.com/osiam/connector4java/pull/103
