### PR TITLE
[fix] fixed distribution unpacked folder name to fit for osiam dist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,8 +183,6 @@
     </dependencies>
 
     <build>
-        <finalName>addon-administration</finalName>
-
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -193,6 +191,16 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <warName>${project.artifactId}</warName>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I removed the finalName so the unpacked folder of the zipped distribution fit to the standard... this is required to fit to the standard process in the osiam distribution: https://github.com/osiam/distribution/pull/8

also the created war now named with it's version, e.g. addon-administration-1.1-SNAPSHOT.war before that fix it was without the version: addon-administration.war. Does this named war needed by someone? Please check before merge.
