### PR TITLE
Remove field `expiry` from OAuth client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 1.5 - Unreleased
 
 ### Changes
+
+- remove field `expiry` from OAuth client in SQL scripts
+
+    The field `expiry` has been removed from the auth-server (osiam/auth-server#9)
+    and must be removed from the SQL scripts too.
+
 - adjust some attributes of the 'admin' group
 
     - set `external_id` to NULL

--- a/src/main/sql/client.sql
+++ b/src/main/sql/client.sql
@@ -4,12 +4,10 @@
 -- auth-server, before you deploy the addon-administration!
 --
 
-INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, expiry,
-                          id, implicit_approval, redirect_uri, refreshtokenvalidityseconds,
-                          validityinseconds)
-VALUES (20, 28800, 'super-secret', NULL,
-        'addon-administration-client', TRUE, 'http://localhost:8080/addon-administration', 86400,
-        0);
+INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, id,
+                          implicit_approval, redirect_uri, refreshtokenvalidityseconds, validityinseconds)
+VALUES (20, 28800, 'super-secret', 'addon-administration-client',
+        TRUE, 'http://localhost:8080/addon-administration', 86400, 0);
 
 INSERT INTO osiam_client_scopes (id, scope) VALUES (20, 'GET');
 INSERT INTO osiam_client_scopes (id, scope) VALUES (20, 'POST');

--- a/src/main/sql/example_data.sql
+++ b/src/main/sql/example_data.sql
@@ -2,12 +2,10 @@
 -- DEPRECATED: replaced by extension.sql and admin_group.sql
 --
 
-INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, expiry,
-                          id, implicit_approval, redirect_uri, refreshtokenvalidityseconds,
-                          validityinseconds)
-VALUES (20, 28800, 'super-secret', NULL,
-        'addon-administration-client', TRUE, 'http://localhost:8080/addon-administration', 86400,
-        0);
+INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, id,
+                          implicit_approval, redirect_uri, refreshtokenvalidityseconds, validityinseconds)
+VALUES (20, 28800, 'super-secret', 'addon-administration-client',
+        TRUE, 'http://localhost:8080/addon-administration', 86400, 0);
 
 INSERT INTO osiam_client_scopes (id, scope) VALUES (20, 'GET');
 INSERT INTO osiam_client_scopes (id, scope) VALUES (20, 'POST');

--- a/src/test/resources/database_seed.xml
+++ b/src/test/resources/database_seed.xml
@@ -26,7 +26,7 @@
     <osiam_client internal_id="100003" id="example-client" redirect_uri="http://localhost:8280/"
                   client_secret="secret"
                   accesstokenvalidityseconds="2342" refreshtokenvalidityseconds="2342" validityinseconds="1337"
-                  implicit_approval="false" expiry="1970-01-01 00:00:01"/>
+                  implicit_approval="false"/>
     <osiam_client_grants id="100003" grants="authorization_code"/>
     <osiam_client_grants id="100003" grants="refresh_token"/>
     <osiam_client_grants id="100003" grants="password"/>
@@ -40,7 +40,7 @@
     <osiam_client internal_id="100080" id="short-living-client" redirect_uri="http://localhost:5001/oauth2"
                   client_secret="other-secret"
                   accesstokenvalidityseconds="1" refreshtokenvalidityseconds="2342" validityinseconds="1"
-                  implicit_approval="false" expiry="1970-01-01 00:00:01"/>
+                  implicit_approval="false"/>
     <osiam_client_grants id="100080" grants="authorization_code"/>
     <osiam_client_grants id="100080" grants="refresh_token"/>
     <osiam_client_grants id="100080" grants="password"/>


### PR DESCRIPTION
the field `expiry` has been removed from the auth-server (osiam/auth-server#9) and must be removed from the SQL scripts too.