### PR TITLE
Decrease refresh token validity to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
     - remove unnecessary grants: resource owner credentials grant, client
       credentials grant, refresh token grant
     - increase access token validity to 8 hours
-    - increase refresh token validity to 24 hours
+    - decrease refresh token validity to 0 seconds
     - decrease approval validity to 0 seconds
 
 - rename SQL scripts for installing client and group

--- a/src/main/sql/client.sql
+++ b/src/main/sql/client.sql
@@ -7,7 +7,7 @@
 INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, id,
                           implicit_approval, redirect_uri, refreshtokenvalidityseconds, validityinseconds)
 VALUES (20, 28800, 'super-secret', 'addon-administration-client',
-        TRUE, 'http://localhost:8080/addon-administration', 86400, 0);
+        TRUE, 'http://localhost:8080/addon-administration', 0, 0);
 
 INSERT INTO osiam_client_scopes (id, scope) VALUES (20, 'GET');
 INSERT INTO osiam_client_scopes (id, scope) VALUES (20, 'POST');


### PR DESCRIPTION
Refresh token grant is not supported anyways, so it makes no sense to set a refresh token validity anymore.