### PR TITLE
Add coding conventions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,17 @@ Thank you for considering to contribute to OSIAM.
 This document is here to offer you a few helpful notes to get you started and
 make your experience as smooth as possible. They should be seen as guidelines.
 They are _not_ strict rules and we won't blame anyone who tries to contribute.
-By following the points in this document you will make our lifes a bit easier
-but we will still be happy about your contribution if you don't.
+By following the steps in this document you will make our lives a bit 
+easier but we will still be happy about your contribution if you don't.
 
-## Reporting issues on Github
+## Reporting Issues on Github
 The easiest way to contribute to OSIAM is by filing issues on Github. It does
 not have to be a bug, it can also be a feature request or a suggestion to
-improve our documentation. We will do our best to answer your issue as soon 
+improve our documentation. We will do our best to answer your issue as fast 
 as possible. Before you create an issue on Github please consider doing the
 following:
 
-* Search existing issues before raising a new one. 
+* Search existing issues before creating a new one.
 * If you are reporting a bug please include as much details as possible.
   This might include:
     * Which OS you're using
@@ -24,13 +24,25 @@ following:
     * The expected result
     * The actual result
 
-## The master is read only
+## The Master is Read Only
 We consider the master branch of all OSIAM projects _read only_. That means
 we don't want any code to be added to it without getting reviewed by somebody
 else. For that reason we don't want to accept any modifications to the master
 branch that doesn't have its origin in a pull request. We believe that not 
 only does this improve the quality of our code base tremendously, but also 
 offers us a good way to learn from our mistakes.
+
+## Coding Conventions
+As coding conventions we adopted the Oracle's official [Coding conventions for
+the Java Programming Language]
+(http://www.oracle.com/technetwork/java/javase/documentation/codeconvtoc-136057.html)
+with the following two exceptions:
+
+* We use a line width of 120 characters.
+* We indent with four spaces and no tabs.
+
+You can find a formatter definition for the Eclipse IDE [here]
+(https://gist.github.com/tkrille/46e284a17c744243bc20).
 
 ## Pull Requests
 If you want us to review a pull request with your modifications to OSIAM
@@ -44,6 +56,8 @@ please consider doing the following:
 * Make sure the [integration tests]
   (https://github.com/osiam/connector4java-integration-tests) pass.
 * Please squash related commits.
+* Please make sure that your pull request adheres to our [coding conventions]
+  (#coding-conventions).
 
 ## Rebase
 If while you've been working in the feature branch new commits were added to
@@ -100,4 +114,3 @@ feel save and appreciated.
 Much of this document was taken from and inspired by the `CONTRIBUTING.md`
 document of the excellent [crate](https.//crate.io) project. We use it with
 a lot of love.
-


### PR DESCRIPTION
This adds some information about our coding conventions to
the `CONTRIBUTING.md` as discussed in [osiam#11]
(https://github.com/osiam/osiam/issues/11)