### PR TITLE
Downgrade Jersey to 2.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.connectors</groupId>
             <artifactId>jersey-apache-connector</artifactId>
-            <version>2.21</version>
+            <version>2.17</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is necessary, because Jersey 2.18 introduced a change that let the retrieval of extension fail. This has to be further investigated.