### PR TITLE
Remove explicit dependency on Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,24 +92,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.5.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.5.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.5.3</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.glassfish.jersey.connectors</groupId>
             <artifactId>jersey-apache-connector</artifactId>
             <version>2.17</version>


### PR DESCRIPTION
After we restored compatibility of the connector with older Jackson version, we can now remove the explicit dependency on Jackson. Spring Boot already defines a working Jackson version that we should use. This way we reduce the complexity of the POM and also get automatic updates with new Spring Boot releases instead of relying on the explicit version, which will be outdated in the future.