### PR TITLE
Restore support for OSIAM 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,24 @@ An administration for OSIAM.
 
 ## Installation
 
-Copy the addon-administration.war into the tomcat container (webapps). After
-that you must add a new properties file into tomcat classpath. For the moment,
-we assume that the directory /etc/osiam is included in the classpath. Now
-create a new file named "addon-administration.properties" in that directory
-(/etc/osiam/addon-administration.properties). Edit the file with an editor of
+Copy the `addon-administration.war` into the Tomcat container (`webapps`). After
+that you must add a new properties file into Tomcat classpath. For the moment,
+we assume that the directory `/etc/osiam` is included in the classpath. Now
+create a new file named `addon-administration.properties` in that directory
+(`/etc/osiam/addon-administration.properties`). Edit the file with an editor of
 your choice and add the following content:
 
 ## Configuration
 
-### OSIAM Endpoints
+### OSIAM Endpoints (OSIAM 3.x)
     org.osiam.endpoint=http://<osiam-address>/osiam
+
+### OSIAM Endpoints (OSIAM 2.x)
+    org.osiam.authServerEndpoint=http://<osiam-address>/osiam-auth-server
+    org.osiam.resourceServerEndpoint=http://<osiam-address>/osiam-resource-server
+    org.osiam.connector.legacy-schemas=false
+
+### Redirect URI for Authorization Code Grant
     org.osiam.redirectUri=http://<addon-administration-address>/addon-administration/
 
 ### Client credentials
@@ -56,15 +63,13 @@ path:
 
 ## Database setup
 
-**PRECONDITION**
-
-You need to import the sql scripts into your postgres database which you will
-find in the OSIAM resource server project!
-
 ### OAuth client
 
-You need to add a specific client for administration in the auth-server
-database (client.sql).
+You need to add a specific client for administration in OSIAM's database
+(`client.sql`).
+
+**Note for users of OSIAM 2.x:** the `client.sql` must be run against the
+auth-server's database.
 
 Start the database commandline:
 
@@ -75,13 +80,16 @@ the sources by calling
 
     $ psql -f ./sql/client.sql -U osiam
 
-but update the client.sql before you import it and sync the data with
-the above mentioned addon-administration.properties!
+but update the `client.sql` before you import it and sync the data with the
+aforementioned addon-administration.properties!
 
 ### Admin group
 
-You need to add a specific group for administration in the OSIAM database
-(admin_group.sql).
+You need to add a specific group for administration in OSIAM's database
+(`admin_group.sql`).
+
+**Note for users of OSIAM 2.x:** the `admin_group.sql` must be run against the
+resource-server's database.
 
 Start the database commandline:
 
@@ -92,5 +100,5 @@ the sources by calling
 
     $ psql -f ./sql/admin_group.sql -U osiam
 
-but update the admin_group.sql before you import it and sync the data with
-any existing data in the osiam database.
+but update the `admin_group.sql` before you import it and sync the data with
+any existing data in OSIAM's database.

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>connector4java</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>1.8-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.osiam</groupId>
     <artifactId>addon-administration</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>1.7-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>OSIAM Administration</name>

--- a/src/main/deploy/addon-administration.properties
+++ b/src/main/deploy/addon-administration.properties
@@ -1,5 +1,14 @@
-# OSIAM endpoints
+# OSIAM endpoint (OSIAM 3.x)
 org.osiam.endpoint=http://localhost:8080/osiam
+
+# OSIAM endpoints (OSIAM 2.x)
+org.osiam.authServerEndpoint=http://localhost:8080/osiam-auth-server
+org.osiam.resourceServerEndpoint=http://localhost:8080/osiam-resource-server
+
+# Enable legacy schemas mode, if you use OSIAM <= 2.3 (resource-server 2.2)
+org.osiam.connector.legacy-schemas=false
+
+# Redirect URI for OAuth 2 authorization code grant
 org.osiam.redirectUri=http://localhost:8080/addon-administration/
 
 # Please sync the client data with the ../sql/client.sql

--- a/src/main/java/org/osiam/addons/administration/config/ConnectorBuilder.java
+++ b/src/main/java/org/osiam/addons/administration/config/ConnectorBuilder.java
@@ -1,6 +1,8 @@
 package org.osiam.addons.administration.config;
 
+import com.google.common.base.Strings;
 import org.osiam.client.OsiamConnector;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,19 +19,38 @@ public class ConnectorBuilder {
     @Value("${org.osiam.clientSecret}")
     private String clientSecret;
 
-    @Value("${org.osiam.endpoint}")
+    @Value("${org.osiam.authServerEndpoint:}")
+    private String authServerEndpoint;
+
+    @Value("${org.osiam.resourceServerEndpoint:}")
+    private String resourceServerEndpoint;
+
+    @Value("${org.osiam.endpoint:}")
     private String osiamEndpoint;
+
+    @Value("${org.osiam.connector.legacy-schemas:false}")
+    private boolean useLegacySchemas;
 
     @Value("${org.osiam.redirectUri}")
     private String redirectUri;
 
     @Bean
     public OsiamConnector build() {
-        return new OsiamConnector.Builder()
-                .withEndpoint(osiamEndpoint)
+        OsiamConnector.Builder builder = new OsiamConnector.Builder()
                 .setClientRedirectUri(redirectUri)
                 .setClientId(clientId)
-                .setClientSecret(clientSecret)
-                .build();
+                .setClientSecret(clientSecret);
+
+        if (!Strings.isNullOrEmpty(osiamEndpoint)) {
+            builder.withEndpoint(osiamEndpoint);
+        } else if (!Strings.isNullOrEmpty(authServerEndpoint) && !Strings.isNullOrEmpty(resourceServerEndpoint)) {
+            builder.setAuthServerEndpoint(authServerEndpoint)
+                    .setResourceServerEndpoint(resourceServerEndpoint)
+                    .withLegacySchemas(useLegacySchemas);
+        } else {
+            throw new BeanCreationException("Error creating OSIAM connector. No OSIAM endpoint set.");
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/org/osiam/addons/administration/config/ConnectorBuilder.java
+++ b/src/main/java/org/osiam/addons/administration/config/ConnectorBuilder.java
@@ -26,7 +26,7 @@ public class ConnectorBuilder {
     @Bean
     public OsiamConnector build() {
         return new OsiamConnector.Builder()
-                .setEndpoint(osiamEndpoint)
+                .withEndpoint(osiamEndpoint)
                 .setClientRedirectUri(redirectUri)
                 .setClientId(clientId)
                 .setClientSecret(clientSecret)


### PR DESCRIPTION
We only want to maintain a single version of the addon by now, so old
behavior must be restored. This restores the deleted configuration
properties to connect to OSIAM 2.x and adds support for the new legacy
schema mode of the connector.