### PR TITLE
Don't lose group memberships when updating group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # OSIAM addon-administration
 
+## Unreleased
+
+### Fixes
+
+- Fix: Changing the displayName removes all members from a group
+
+    Fixes #119
+
 ## 1.8 - 2015-12-27
 
 **NOTICE:** This version should be compatible with all versions of OSIAM >= 2.2.

--- a/src/main/java/org/osiam/addons/administration/controller/group/EditGroupController.java
+++ b/src/main/java/org/osiam/addons/administration/controller/group/EditGroupController.java
@@ -5,7 +5,7 @@ import javax.validation.Valid;
 
 import org.osiam.addons.administration.controller.AdminController;
 import org.osiam.addons.administration.controller.GenericController;
-import org.osiam.addons.administration.model.command.UpdateGroupCommand;
+import org.osiam.addons.administration.model.command.EditGroupCommand;
 import org.osiam.addons.administration.service.GroupService;
 import org.osiam.addons.administration.util.RedirectBuilder;
 import org.osiam.client.exception.ConflictException;
@@ -45,7 +45,7 @@ public class EditGroupController extends GenericController {
 
         Group group = groupService.getGroup(id);
 
-        modelAndView.addObject(MODEL, new UpdateGroupCommand(group));
+        modelAndView.addObject(MODEL, new EditGroupCommand(group));
 
         return modelAndView;
     }
@@ -67,7 +67,7 @@ public class EditGroupController extends GenericController {
     }
 
     @RequestMapping(method = RequestMethod.POST)
-    public String handleGroupUpdate(@Valid @ModelAttribute(MODEL) UpdateGroupCommand command,
+    public String handleGroupUpdate(@Valid @ModelAttribute(MODEL) EditGroupCommand command,
             BindingResult bindingResult) {
         boolean isDuplicated = false;
 

--- a/src/main/java/org/osiam/addons/administration/model/command/EditGroupCommand.java
+++ b/src/main/java/org/osiam/addons/administration/model/command/EditGroupCommand.java
@@ -1,48 +1,32 @@
 package org.osiam.addons.administration.model.command;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.hibernate.validator.constraints.NotEmpty;
 import org.osiam.resources.scim.Group;
-import org.osiam.resources.scim.MemberRef;
 import org.osiam.resources.scim.UpdateGroup;
 
 /**
  * Command object for the group update view.
  */
-public class UpdateGroupCommand {
+public class EditGroupCommand {
     private String id;
 
     @NotEmpty
     private String displayName;
     private String externalId;
 
-    private List<String> memberIds = new ArrayList<String>();
-
     /**
      * Creates a new UpdateGroupCommand based on the given {@link Group}.
      *
-     * @param group
-     *            the user
+     * @param group the group
      */
-    public UpdateGroupCommand(Group group) {
+    public EditGroupCommand(Group group) {
         setId(group.getId());
 
         setExternalId(group.getExternalId());
         setDisplayName(group.getDisplayName());
-
-        if (group.getMembers() != null) {
-            for (MemberRef ref : group.getMembers()) {
-                memberIds.add(ref.getValue());
-            }
-        }
     }
 
-    /**
-     * Creates a new UpdateGroupCommand.
-     */
-    public UpdateGroupCommand() {
+    EditGroupCommand() {
     }
 
     /**
@@ -57,19 +41,10 @@ public class UpdateGroupCommand {
     /**
      * Sets the displayname.
      *
-     * @param displayName
-     *            the displayname to set
+     * @param displayName the displayname to set
      */
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
-    }
-
-    public List<String> getMemberIds() {
-        return memberIds;
-    }
-
-    public void setMemberIds(List<String> memberIds) {
-        this.memberIds = memberIds;
     }
 
     public String getId() {
@@ -102,12 +77,6 @@ public class UpdateGroupCommand {
         } else {
             builder.updateExternalId(getExternalId());
         }
-
-        builder.deleteMembers();
-        for (String member : memberIds) {
-            builder.addMember(member);
-        }
-
         return builder.build();
     }
 }

--- a/src/main/resources/templates/group/editGroup.html
+++ b/src/main/resources/templates/group/editGroup.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <th:block th:include="head :: includes"></th:block>
+    <th:block th:include="head :: includes"/>
 
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title th:text="#{edit_group.title}">Edit group</title>
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-<th:block th:include="header :: header"></th:block>
+<th:block th:include="header :: header"/>
 
 <div class="container shadow" id="content">
     <div th:replace="makros :: topbar">


### PR DESCRIPTION
Don't drop a group's mebers when updating its `displayName` or
`externalId` property. This fixes #119