### PR TITLE
There is no docker image to exclude anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,6 @@
                             <src>src/integrationtest/docker</src>
                             <version>1.16</version>
                             <host>${docker.host}</host>
-                            <exclude>${excluded.container}</exclude>
                             <removeIntermediateImages>${docker.removeIntermediateImages}</removeIntermediateImages>
                             <cache>false</cache>
                             <permissionErrorTolerant>true</permissionErrorTolerant>


### PR DESCRIPTION
The administration integration tests are only running against one
database, thats why there is no need to exclude the other database
docker image.