### PR TITLE
Upload distribution to Bintray on release

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,3 +39,6 @@ deployment:
     owner: osiam
     commands:
       - curl -T target/addon-administration.war -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:addon-administration" -H "X-Bintray-Version:${CIRCLE_TAG}" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/addon-administration/${CIRCLE_TAG}/addon-administration-${CIRCLE_TAG}.war
+      - mvn assembly:single
+      - curl -T target/addon-administration-${CIRCLE_TAG}-distribution.tar.gz -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:addon-administration" -H "X-Bintray-Version:${CIRCLE_TAG}-distribution-tgz" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/addon-self-administration/${CIRCLE_TAG}/addon-self-administration-${CIRCLE_TAG}-distribution.tar.gz
+      - curl -T target/addon-administration-${CIRCLE_TAG}-distribution.zip -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:addon-administration" -H "X-Bintray-Version:${CIRCLE_TAG}-distribution-zip" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/addon-self-administration/${CIRCLE_TAG}/addon-self-administration-${CIRCLE_TAG}-distribution.zip

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,17 @@
                     </jacocoReports>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -462,35 +473,6 @@
                                 <goals>
                                     <goal>stop</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>distribution</id>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <version>2.6</version>
-                        <executions>
-                            <execution>
-                                <id>distribution-assembly</id>
-                                <phase>package</phase>
-
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-
-                                <configuration>
-                                    <descriptors>
-                                        <descriptor>src/assembly/distribution.xml</descriptor>
-                                    </descriptors>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
The profile is not necessary anymore, as we call the assembly goal
directly from the command line.

Resolves #142