### PR TITLE
Remove Evolvis releases repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,13 +200,6 @@
 
     <repositories>
         <repository>
-            <id>osiam-releases</id>
-            <url>https://maven-repo.evolvis.org/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <snapshots />
             <id>osiam-snapshots</id>
             <name>libs-snapshot</name>


### PR DESCRIPTION
There are no releases on the Evolvis releases repo, that we wouldn't get
from the central too.